### PR TITLE
Add supersede / update product version functionality in Registry Manager

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
@@ -17,6 +17,7 @@ import gov.nasa.pds.registry.mgr.cmd.CliCommand;
 import gov.nasa.pds.registry.mgr.cmd.data.DeleteDataCmd;
 import gov.nasa.pds.registry.mgr.cmd.data.ExportFileCmd;
 import gov.nasa.pds.registry.mgr.cmd.data.SetArchiveStatusCmd;
+import gov.nasa.pds.registry.mgr.cmd.data.UpdateAltIdsCmd;
 import gov.nasa.pds.registry.mgr.cmd.dd.DeleteDDCmd;
 import gov.nasa.pds.registry.mgr.cmd.dd.ExportDDCmd;
 import gov.nasa.pds.registry.mgr.cmd.dd.ListDDCmd;
@@ -65,6 +66,7 @@ public class RegistryManagerCli
         System.out.println("  delete-data          Delete data from registry index");
         System.out.println("  export-file          Export a file from blob storage");
         System.out.println("  set-archive-status   Set product archive status");
+        System.out.println("  update-alt-ids       Update alternate IDs");
         
         System.out.println();
         System.out.println("Registry:");
@@ -244,9 +246,9 @@ public class RegistryManagerCli
         
         // Data
         commands.put("delete-data", new DeleteDataCmd());
-        //commands.put("export-data", new ExportDataCmd());
         commands.put("export-file", new ExportFileCmd());
         commands.put("set-archive-status", new SetArchiveStatusCmd());
+        commands.put("update-alt-ids", new UpdateAltIdsCmd());
     }
     
     

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/UpdateAltIdsCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/UpdateAltIdsCmd.java
@@ -147,7 +147,9 @@ public class UpdateAltIdsCmd implements CliCommand
     private void updateIds(Map<String, List<String>> newIds) throws Exception
     {
         RegistryDao dao = RegistryManager.getInstance().getRegistryDao();
+        
         Map<String, Set<String>> existingIds = dao.getAlternateIds(newIds.keySet());
+        if(existingIds == null || existingIds.isEmpty()) return;
         
         for(Map.Entry<String, Set<String>> entry: existingIds.entrySet())            
         {

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/UpdateAltIdsCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/UpdateAltIdsCmd.java
@@ -5,7 +5,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -16,10 +15,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.ResponseException;
-import org.elasticsearch.client.RestClient;
 
 import gov.nasa.pds.registry.common.cfg.RegistryCfg;
-import gov.nasa.pds.registry.common.es.client.EsClientFactory;
 import gov.nasa.pds.registry.common.es.client.EsUtils;
 import gov.nasa.pds.registry.common.util.CloseUtils;
 import gov.nasa.pds.registry.mgr.Constants;
@@ -84,7 +81,6 @@ public class UpdateAltIdsCmd implements CliCommand
     private void updateIds(File file) throws Exception
     {
         BufferedReader rd = null;
-        Logger log = LogManager.getLogger(this.getClass());
 
         try
         {
@@ -137,6 +133,7 @@ public class UpdateAltIdsCmd implements CliCommand
                 idMap.put(ids[0], newIds);
                 idMap.put(ids[1], newIds);
                 
+                log.info("Updating " + ids[0] + " -> " + ids[1]);
                 updateIds(idMap);
             }
         }

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/UpdateAltIdsCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/UpdateAltIdsCmd.java
@@ -1,0 +1,79 @@
+package gov.nasa.pds.registry.mgr.cmd.data;
+
+
+import org.apache.commons.cli.CommandLine;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+
+import gov.nasa.pds.registry.common.es.client.EsClientFactory;
+import gov.nasa.pds.registry.common.es.client.EsUtils;
+import gov.nasa.pds.registry.common.util.CloseUtils;
+import gov.nasa.pds.registry.mgr.Constants;
+import gov.nasa.pds.registry.mgr.cmd.CliCommand;
+
+
+/**
+ * A CLI command to update product's alternate IDs in Elasticsearch.
+ * 
+ * @author karpenko
+ */
+public class UpdateAltIdsCmd implements CliCommand
+{
+
+    
+    /**
+     * Constructor
+     */
+    public UpdateAltIdsCmd()
+    {
+    }
+
+    
+    @Override
+    public void run(CommandLine cmdLine) throws Exception
+    {
+        if(cmdLine.hasOption("help"))
+        {
+            printHelp();
+            return;
+        }
+
+        String esUrl = cmdLine.getOptionValue("es", "http://localhost:9200");
+        String indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
+        String authPath = cmdLine.getOptionValue("auth");
+
+        RestClient client = null;
+        
+        try
+        {
+            client = EsClientFactory.createRestClient(esUrl, authPath);
+
+        }
+        catch(ResponseException ex)
+        {
+            throw new Exception(EsUtils.extractErrorMessage(ex));
+        }
+        finally
+        {
+            CloseUtils.close(client);
+        }
+    }
+
+    
+    public void printHelp()
+    {
+        System.out.println("Usage: registry-manager update-alt-ids <options>");
+
+        System.out.println();
+        System.out.println("Update product's alternate IDs");
+        System.out.println();
+        System.out.println("Required parameters:");
+        System.out.println("  -file <path>      CSV file with the list of IDs");
+        System.out.println("Optional parameters:");
+        System.out.println("  -auth <file>      Authentication config file");
+        System.out.println("  -es <url>         Elasticsearch URL. Default is http://localhost:9200");
+        System.out.println("  -index <name>     Elasticsearch index name. Default is 'registry'");
+        System.out.println();
+    }
+
+}

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/UpdateAltIdsCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/UpdateAltIdsCmd.java
@@ -1,7 +1,14 @@
 package gov.nasa.pds.registry.mgr.cmd.data;
 
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 
@@ -19,7 +26,6 @@ import gov.nasa.pds.registry.mgr.cmd.CliCommand;
  */
 public class UpdateAltIdsCmd implements CliCommand
 {
-
     
     /**
      * Constructor
@@ -42,12 +48,19 @@ public class UpdateAltIdsCmd implements CliCommand
         String indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
         String authPath = cmdLine.getOptionValue("auth");
 
+        String filePath = cmdLine.getOptionValue("file");
+        if(filePath == null) throw new Exception("Missing required parameter '-file'");
+        File file = new File(filePath);
+        if(!file.exists()) throw new Exception("Input file doesn't exist: " + file.getAbsolutePath());
+        
         RestClient client = null;
         
         try
         {
             client = EsClientFactory.createRestClient(esUrl, authPath);
 
+            updateIds(client, file);
+            
         }
         catch(ResponseException ex)
         {
@@ -59,6 +72,59 @@ public class UpdateAltIdsCmd implements CliCommand
         }
     }
 
+    
+    private void updateIds(RestClient client, File file) throws Exception
+    {
+        BufferedReader rd = null;
+        Logger log = LogManager.getLogger(this.getClass());
+
+        try
+        {
+            rd = new BufferedReader(new FileReader(file));
+            
+            String line;
+            int lineNum = 0;
+            
+            while((line = rd.readLine()) != null)
+            {
+                lineNum++;
+                line = line.trim();
+                
+                String[] ids = StringUtils.split(line, ",;\t ");
+                if(ids == null || ids.length != 2)
+                {
+                    log.warn("Line " + lineNum + " has invalid value: [" + line + "]");
+                    continue;
+                }
+                
+                if(!ids[0].contains("::"))
+                {
+                    log.warn("Line " + lineNum + " has invalid LIDVID: [" + ids[0] + "]");
+                    continue;
+                }
+                
+                if(!ids[1].contains("::"))
+                {
+                    log.warn("Line " + lineNum + " has invalid LIDVID: [" + ids[1] + "]");
+                    continue;
+                }
+
+                updateIds(client, ids);
+            }
+        }
+        finally
+        {
+            CloseUtils.close(rd);
+        }
+    }
+    
+    
+    private void updateIds(RestClient client, String[] lidvids) throws Exception
+    {
+        System.out.println(lidvids[0]);
+        System.out.println(lidvids[1]);
+    }
+    
     
     public void printHelp()
     {

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryDao.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryDao.java
@@ -1,0 +1,62 @@
+package gov.nasa.pds.registry.mgr.dao;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+
+import gov.nasa.pds.registry.common.es.client.SearchResponseParser;
+import gov.nasa.pds.registry.mgr.dao.resp.GetAltIdsParser;
+
+
+public class RegistryDao
+{
+    private Logger log;
+    private RestClient client;
+    private String indexName;
+
+    private boolean pretty = false;
+
+    
+    public RegistryDao(RestClient client, String indexName)
+    {
+        log = LogManager.getLogger(this.getClass());
+        this.client = client;
+        this.indexName = indexName;
+    }
+
+    
+    public void setPretty(boolean b)
+    {
+        this.pretty = b;
+    }
+    
+    
+    public Map<String, Set<String>> getAlternateIds(Collection<String> ids) throws Exception
+    {
+        if(ids == null || ids.isEmpty()) return null;
+        
+        RegistryRequestBuilder bld = new RegistryRequestBuilder();
+        String jsonReq = bld.createGetAlternateIdsRequest(ids);
+        
+        String reqUrl = "/" + indexName + "/_search";
+        if(pretty) reqUrl += "?pretty";
+        
+        Request req = new Request("GET", reqUrl);
+        req.setJsonEntity(jsonReq);
+        Response resp = client.performRequest(req);
+
+        //DebugUtils.dumpResponseBody(resp);
+        
+        GetAltIdsParser cb = new GetAltIdsParser();
+        SearchResponseParser parser = new SearchResponseParser();
+        parser.parseResponse(resp, cb);
+        
+        return cb.getIdMap();
+    }
+}

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryDao.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryDao.java
@@ -1,5 +1,7 @@
 package gov.nasa.pds.registry.mgr.dao;
 
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -11,12 +13,15 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 
 import gov.nasa.pds.registry.common.es.client.SearchResponseParser;
+import gov.nasa.pds.registry.common.es.dao.BulkResponseParser;
+import gov.nasa.pds.registry.common.util.CloseUtils;
 import gov.nasa.pds.registry.mgr.dao.resp.GetAltIdsParser;
 
 
 public class RegistryDao
 {
     private Logger log;
+    
     private RestClient client;
     private String indexName;
 
@@ -26,6 +31,7 @@ public class RegistryDao
     public RegistryDao(RestClient client, String indexName)
     {
         log = LogManager.getLogger(this.getClass());
+        
         this.client = client;
         this.indexName = indexName;
     }
@@ -59,4 +65,38 @@ public class RegistryDao
         
         return cb.getIdMap();
     }
+    
+    
+    public void updateAlternateIds(Map<String, Set<String>> newIds) throws Exception
+    {
+        if(newIds == null || newIds.isEmpty()) return;
+        
+        RegistryRequestBuilder bld = new RegistryRequestBuilder();
+        String json = bld.createUpdateAltIdsRequest(newIds);
+        log.debug("Request:\n" + json);
+        
+        String reqUrl = "/" + indexName + "/_bulk"; //?refresh=wait_for";
+        Request req = new Request("POST", reqUrl);
+        req.setJsonEntity(json);
+        
+        Response resp = client.performRequest(req);
+        
+        // Check for Elasticsearch errors.
+        InputStream is = null;
+        InputStreamReader rd = null;
+        try
+        {
+            is = resp.getEntity().getContent();
+            rd = new InputStreamReader(is);
+            
+            BulkResponseParser parser = new BulkResponseParser();
+            parser.parse(rd);
+        }
+        finally
+        {
+            CloseUtils.close(rd);
+            CloseUtils.close(is);
+        }
+    }
+
 }

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryDao.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryDao.java
@@ -32,8 +32,8 @@ public class RegistryDao
 
     /**
      * Constructor
-     * @param client Elasticsearch client, Elasticsearch index
-     * @param indexName
+     * @param client Elasticsearch client
+     * @param indexName Elasticsearch index
      */
     public RegistryDao(RestClient client, String indexName)
     {

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryDao.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryDao.java
@@ -17,7 +17,10 @@ import gov.nasa.pds.registry.common.es.dao.BulkResponseParser;
 import gov.nasa.pds.registry.common.util.CloseUtils;
 import gov.nasa.pds.registry.mgr.dao.resp.GetAltIdsParser;
 
-
+/**
+ * Data access object
+ * @author karpenko
+ */
 public class RegistryDao
 {
     private Logger log;
@@ -27,7 +30,11 @@ public class RegistryDao
 
     private boolean pretty = false;
 
-    
+    /**
+     * Constructor
+     * @param client Elasticsearch client, Elasticsearch index
+     * @param indexName
+     */
     public RegistryDao(RestClient client, String indexName)
     {
         log = LogManager.getLogger(this.getClass());
@@ -37,12 +44,22 @@ public class RegistryDao
     }
 
     
+    /**
+     * Generate pretty JSONs for debugging
+     * @param b boolean flag
+     */
     public void setPretty(boolean b)
     {
         this.pretty = b;
     }
     
     
+    /**
+     * Get product's alternative IDs by primary key 
+     * @param ids primary keys (usually LIDVIDs)
+     * @return ID map: key = product primary key (usually LIDVID), value = set of alternate IDs 
+     * @throws Exception an exception
+     */
     public Map<String, Set<String>> getAlternateIds(Collection<String> ids) throws Exception
     {
         if(ids == null || ids.isEmpty()) return null;
@@ -67,6 +84,12 @@ public class RegistryDao
     }
     
     
+    /**
+     * Update alternate IDs by primary keys
+     * @param newIds ID map: key = product primary key (usually LIDVID), 
+     * value = additional alternate IDs to be added to existing alternate IDs.
+     * @throws Exception an exception
+     */
     public void updateAlternateIds(Map<String, Set<String>> newIds) throws Exception
     {
         if(newIds == null || newIds.isEmpty()) return;

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryManager.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryManager.java
@@ -23,6 +23,7 @@ public class RegistryManager
     private RestClient esClient;
     private SchemaDao schemaDao;
     private DataDictionaryDao dataDictionaryDao;
+    private RegistryDao registryDao;
     
     
     /**
@@ -47,7 +48,8 @@ public class RegistryManager
         log.info("Registry index: " + indexName);
         
         schemaDao = new SchemaDao(esClient, indexName);
-        dataDictionaryDao = new DataDictionaryDao(esClient, indexName);                
+        dataDictionaryDao = new DataDictionaryDao(esClient, indexName);
+        registryDao = new RegistryDao(esClient, indexName);
     }
     
     
@@ -101,6 +103,16 @@ public class RegistryManager
     public DataDictionaryDao getDataDictionaryDao()
     {
         return dataDictionaryDao;
+    }
+
+    
+    /**
+     * Get registry DAO object.
+     * @return Registry DAO
+     */
+    public RegistryDao getRegistryDao()
+    {
+        return registryDao;
     }
 
 }

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryRequestBuilder.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryRequestBuilder.java
@@ -273,7 +273,6 @@ public class RegistryRequestBuilder
     /**
      * Build a query to select alternate ids by document primary key
      * @param ids list of primary keys (lidvids right now)
-     * @param pageSize request page size
      * @return JSON
      * @throws Exception an exception
      */

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryRequestBuilder.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryRequestBuilder.java
@@ -5,6 +5,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.util.Collection;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -286,6 +287,49 @@ public class RegistryRequestBuilder
         writer.name("script").value("ctx._source.archive_status = '" + status + "'");
         // Query
         EsQueryUtils.appendFilterQuery(writer, field, value);
+        writer.endObject();
+
+        writer.close();
+        return out.toString();
+    }
+
+    
+    /**
+     * Build a query to select alternate ids by document primary key
+     * @param ids list of primary keys (lidvids right now)
+     * @param pageSize request page size
+     * @return JSON
+     * @throws Exception an exception
+     */
+    public String createGetAlternateIdsRequest(Collection<String> ids) throws Exception
+    {
+        if(ids == null || ids.isEmpty()) throw new Exception("Missing ids");
+            
+        StringWriter out = new StringWriter();
+        JsonWriter writer = createJsonWriter(out);
+
+        // Create ids query
+        writer.beginObject();
+
+        // Exclude source from response
+        writer.name("_source").value("alternate_ids");
+        writer.name("size").value(ids.size());
+
+        writer.name("query");
+        writer.beginObject();
+        writer.name("ids");
+        writer.beginObject();
+        
+        writer.name("values");
+        writer.beginArray();
+        for(String id: ids)
+        {
+            writer.value(id);
+        }
+        writer.endArray();
+        
+        writer.endObject();
+        writer.endObject();
         writer.endObject();
 
         writer.close();

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/resp/GetAltIdsParser.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/resp/GetAltIdsParser.java
@@ -1,0 +1,58 @@
+package gov.nasa.pds.registry.mgr.dao.resp;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import gov.nasa.pds.registry.common.es.client.SearchResponseParser;
+
+
+public class GetAltIdsParser implements SearchResponseParser.Callback
+{
+    private Map<String, Set<String>> map;
+    
+    
+    public GetAltIdsParser()
+    {
+        map = new TreeMap<>();
+    }
+
+    
+    public Map<String, Set<String>> getIdMap()
+    {
+        return map;
+    }
+    
+    
+    @Override
+    public void onRecord(String id, Object rec) throws Exception
+    {
+        if(rec instanceof Map<?, ?>)
+        {
+            Object obj = ((Map<?, ?>)rec).get("alternate_ids");
+            if(obj == null) return;
+            
+            // Multiple values
+            if(obj instanceof List<?>)
+            {
+                Set<String> altIds = new TreeSet<>();
+                for(Object item: (List<?>)obj)
+                {
+                    altIds.add(item.toString());
+                }
+                
+                map.put(id, altIds);
+            }
+            // Single value
+            else if(obj instanceof String)
+            {
+                Set<String> altIds = new TreeSet<>();
+                altIds.add((String)obj);
+                map.put(id, altIds);
+            }
+        }
+    }
+
+}

--- a/src/main/resources/elastic/registry.json
+++ b/src/main/resources/elastic/registry.json
@@ -29,6 +29,7 @@
       "lid": { "type": "keyword" },
       "vid": { "type": "float" },
       "lidvid": { "type": "keyword" },
+      "alternate_ids": { "type": "keyword" },
 
       "title": {"type": "text", "analyzer": "english"},
       "description": {"type": "text", "analyzer": "english"},

--- a/src/test/java/tt/TestEsQueryBuilder.java
+++ b/src/test/java/tt/TestEsQueryBuilder.java
@@ -11,9 +11,6 @@ public class TestEsQueryBuilder
         
         testDelete();
         System.out.println();
-        
-        testUpdateStatus();
-        System.out.println();
     }
 
 
@@ -33,10 +30,4 @@ public class TestEsQueryBuilder
     }
 
     
-    private static void testUpdateStatus() throws Exception
-    {
-        RegistryRequestBuilder bld = new RegistryRequestBuilder(true);
-        String json = bld.createUpdateStatusRequest("STAGED", "lidvid", "test::1.0");
-        System.out.println(json);
-    }
 }

--- a/src/test/java/tt/TestRegistryDao.java
+++ b/src/test/java/tt/TestRegistryDao.java
@@ -1,0 +1,33 @@
+package tt;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+
+import org.elasticsearch.client.RestClient;
+
+import gov.nasa.pds.registry.common.es.client.EsClientFactory;
+import gov.nasa.pds.registry.mgr.dao.RegistryDao;
+
+
+public class TestRegistryDao
+{
+
+    public static void main(String[] args) throws Exception
+    {
+        RestClient client = EsClientFactory.createRestClient("localhost", null);
+        
+        try
+        {
+            RegistryDao dao = new RegistryDao(client, "registry");
+            Map<String, Set<String>> idMap = dao.getAlternateIds(Arrays.asList("urn:nasa:pds:context:instrument:vg1.crs::1.0"));
+            Set<String> altIds = idMap.get("urn:nasa:pds:context:instrument:vg1.crs::1.0");
+            System.out.println(altIds);
+        }
+        finally
+        {
+            client.close();
+        }
+    }
+
+}


### PR DESCRIPTION
## 🗒️ Summary
Add supersede / update product version functionality in Registry Manager

## ⚙️ Test Data and/or Report

**Build the projects** 
(1) Build and install "registry-common" jar first (see https://github.com/NASA-PDS/registry-common/pull/24)
(2) Build registry manager

**Test**

* Ingest two documents (also attached to https://github.com/NASA-PDS/registry/issues/55)
(1) https://pds.nasa.gov/data/pds4/context-pds4/instrument/vg1.crs_1.0_deprecated.xml
(2) https://pds.nasa.gov/data/pds4/context-pds4/instrument/vg1.crs_1.0.xml

* Create a CSV file with one row and 2 columns (old and new LIDVIDs):
```
urn:nasa:pds:context:instrument:crs.vg1::1.0,urn:nasa:pds:context:instrument:vg1.crs::1.0
```

* Run registry manager's new "update-alt-ids" command. Pass a file path of the CSV file:
```
registry-manager update-alt-ids -file /tmp/alt-ids.csv
```

* Check OpenSearch index. Both `urn:nasa:pds:context:instrument:crs.vg1::1.0` and `urn:nasa:pds:context:instrument:vg1.crs::1.0` documents should have following "alternative_ids" values:
```
["urn:nasa:pds:context:instrument:crs.vg1",
"urn:nasa:pds:context:instrument:crs.vg1::1.0",
"urn:nasa:pds:context:instrument:vg1.crs",
"urn:nasa:pds:context:instrument:vg1.crs::1.0"]
```

## ♻️ Related Issues
https://github.com/NASA-PDS/registry/issues/56
https://github.com/NASA-PDS/registry/issues/59

https://github.com/NASA-PDS/pds-api/issues/149
https://github.com/NASA-PDS/pds-api/issues/148
