### PR TITLE
Added upgrade-dd command to Registry manager to upgrade data dictionary

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
@@ -22,6 +22,7 @@ import gov.nasa.pds.registry.mgr.cmd.dd.DeleteDDCmd;
 import gov.nasa.pds.registry.mgr.cmd.dd.ExportDDCmd;
 import gov.nasa.pds.registry.mgr.cmd.dd.ListDDCmd;
 import gov.nasa.pds.registry.mgr.cmd.dd.LoadDDCmd;
+import gov.nasa.pds.registry.mgr.cmd.dd.UpgradeDDCmd;
 import gov.nasa.pds.registry.mgr.cmd.reg.CreateRegistryCmd;
 import gov.nasa.pds.registry.mgr.cmd.reg.DeleteRegistryCmd;
 import gov.nasa.pds.registry.mgr.util.log.Log4jConfigurator;
@@ -79,6 +80,7 @@ public class RegistryManagerCli
         System.out.println("  load-dd              Load data into data dictionary");
         System.out.println("  delete-dd            Delete data from data dictionary");        
         System.out.println("  export-dd            Export data dictionary");
+        System.out.println("  upgrade-dd           Upgrade data dictionary");
 
         System.out.println();
         System.out.println("Other:");
@@ -243,6 +245,7 @@ public class RegistryManagerCli
         commands.put("load-dd", new LoadDDCmd());
         commands.put("delete-dd", new DeleteDDCmd());
         commands.put("export-dd", new ExportDDCmd());
+        commands.put("upgrade-dd", new UpgradeDDCmd());
         
         // Data
         commands.put("delete-data", new DeleteDataCmd());
@@ -311,9 +314,6 @@ public class RegistryManagerCli
         bld = Option.builder("packageId").hasArg().argName("id");
         options.addOption(bld.build());
         
-        bld = Option.builder("all");
-        options.addOption(bld.build());
-        
         bld = Option.builder("status").hasArg().argName("status");
         options.addOption(bld.build());
         
@@ -335,6 +335,13 @@ public class RegistryManagerCli
         options.addOption(bld.build());
         
         bld = Option.builder("v").hasArg().argName("level");
+        options.addOption(bld.build());
+
+        // No arguments
+        bld = Option.builder("all");
+        options.addOption(bld.build());
+
+        bld = Option.builder("r");
         options.addOption(bld.build());
     }
     

--- a/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
@@ -17,6 +17,7 @@ import gov.nasa.pds.registry.mgr.cmd.CliCommand;
 import gov.nasa.pds.registry.mgr.cmd.data.DeleteDataCmd;
 import gov.nasa.pds.registry.mgr.cmd.data.ExportFileCmd;
 import gov.nasa.pds.registry.mgr.cmd.data.SetArchiveStatusCmd;
+import gov.nasa.pds.registry.mgr.cmd.data.UpdateAltIdsCmd;
 import gov.nasa.pds.registry.mgr.cmd.dd.DeleteDDCmd;
 import gov.nasa.pds.registry.mgr.cmd.dd.ExportDDCmd;
 import gov.nasa.pds.registry.mgr.cmd.dd.ListDDCmd;
@@ -65,6 +66,7 @@ public class RegistryManagerCli
         System.out.println("  delete-data          Delete data from registry index");
         System.out.println("  export-file          Export a file from blob storage");
         System.out.println("  set-archive-status   Set product archive status");
+        System.out.println("  update-alt-ids       Update alternate IDs");
         
         System.out.println();
         System.out.println("Registry:");
@@ -244,9 +246,9 @@ public class RegistryManagerCli
         
         // Data
         commands.put("delete-data", new DeleteDataCmd());
-        //commands.put("export-data", new ExportDataCmd());
         commands.put("export-file", new ExportFileCmd());
         commands.put("set-archive-status", new SetArchiveStatusCmd());
+        commands.put("update-alt-ids", new UpdateAltIdsCmd());
     }
     
     

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/UpdateAltIdsCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/UpdateAltIdsCmd.java
@@ -1,0 +1,183 @@
+package gov.nasa.pds.registry.mgr.cmd.data;
+
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.client.ResponseException;
+
+import gov.nasa.pds.registry.common.cfg.RegistryCfg;
+import gov.nasa.pds.registry.common.es.client.EsUtils;
+import gov.nasa.pds.registry.common.util.CloseUtils;
+import gov.nasa.pds.registry.mgr.Constants;
+import gov.nasa.pds.registry.mgr.cmd.CliCommand;
+import gov.nasa.pds.registry.mgr.dao.RegistryDao;
+import gov.nasa.pds.registry.mgr.dao.RegistryManager;
+
+
+/**
+ * A CLI command to update product's alternate IDs in Elasticsearch.
+ * 
+ * @author karpenko
+ */
+public class UpdateAltIdsCmd implements CliCommand
+{
+    private Logger log;
+    
+    /**
+     * Constructor
+     */
+    public UpdateAltIdsCmd()
+    {
+        log = LogManager.getLogger(this.getClass());
+    }
+
+    
+    @Override
+    public void run(CommandLine cmdLine) throws Exception
+    {
+        if(cmdLine.hasOption("help"))
+        {
+            printHelp();
+            return;
+        }
+
+        RegistryCfg cfg = new RegistryCfg();
+        cfg.url = cmdLine.getOptionValue("es", "http://localhost:9200");
+        cfg.indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
+        cfg.authFile = cmdLine.getOptionValue("auth");
+
+        String filePath = cmdLine.getOptionValue("file");
+        if(filePath == null) throw new Exception("Missing required parameter '-file'");
+        File file = new File(filePath);
+        if(!file.exists()) throw new Exception("Input file doesn't exist: " + file.getAbsolutePath());
+        
+        try
+        {
+            RegistryManager.init(cfg);
+            updateIds(file);
+        }
+        catch(ResponseException ex)
+        {
+            throw new Exception(EsUtils.extractErrorMessage(ex));
+        }
+        finally
+        {
+            RegistryManager.destroy();
+        }
+    }
+
+    
+    private void updateIds(File file) throws Exception
+    {
+        BufferedReader rd = null;
+
+        try
+        {
+            rd = new BufferedReader(new FileReader(file));
+            
+            String line;
+            int lineNum = 0;
+            
+            while((line = rd.readLine()) != null)
+            {
+                lineNum++;
+                line = line.trim();
+                
+                String[] ids = StringUtils.split(line, ",;\t ");
+                if(ids == null || ids.length != 2)
+                {
+                    log.warn("Line " + lineNum + " has invalid value: [" + line + "]");
+                    continue;
+                }
+                
+                List<String> newIds = new ArrayList<String>(4);
+                
+                // First LIDVID value (old)
+                int idx = ids[0].indexOf("::");
+                if(idx < 1)
+                {
+                    log.warn("Line " + lineNum + " has invalid LIDVID: [" + ids[0] + "]");
+                    continue;
+                }
+                
+                // Add LIDVID
+                newIds.add(ids[0]);
+                // Add LID
+                newIds.add(ids[0].substring(0, idx));
+                
+                // Second LIDVID value (new)
+                idx = ids[1].indexOf("::");
+                if(idx < 1)
+                {
+                    log.warn("Line " + lineNum + " has invalid LIDVID: [" + ids[1] + "]");
+                    continue;
+                }
+
+                // Add LIDVID
+                newIds.add(ids[1]);
+                // Add LID
+                newIds.add(ids[1].substring(0, idx));
+
+                Map<String, List<String>> idMap = new TreeMap<>();
+                idMap.put(ids[0], newIds);
+                idMap.put(ids[1], newIds);
+                
+                log.info("Updating " + ids[0] + " -> " + ids[1]);
+                updateIds(idMap);
+            }
+        }
+        finally
+        {
+            CloseUtils.close(rd);
+        }
+    }
+    
+    
+    private void updateIds(Map<String, List<String>> newIds) throws Exception
+    {
+        RegistryDao dao = RegistryManager.getInstance().getRegistryDao();
+        
+        Map<String, Set<String>> existingIds = dao.getAlternateIds(newIds.keySet());
+        if(existingIds == null || existingIds.isEmpty()) return;
+        
+        for(Map.Entry<String, Set<String>> entry: existingIds.entrySet())            
+        {
+            List<String> additionalIds = newIds.get(entry.getKey());
+            if(additionalIds != null)
+            {
+                entry.getValue().addAll(additionalIds);
+            }
+        }
+        
+        dao.updateAlternateIds(existingIds);
+    }
+    
+    
+    public void printHelp()
+    {
+        System.out.println("Usage: registry-manager update-alt-ids <options>");
+
+        System.out.println();
+        System.out.println("Update product's alternate IDs");
+        System.out.println();
+        System.out.println("Required parameters:");
+        System.out.println("  -file <path>      CSV file with the list of IDs");
+        System.out.println("Optional parameters:");
+        System.out.println("  -auth <file>      Authentication config file");
+        System.out.println("  -es <url>         Elasticsearch URL. Default is http://localhost:9200");
+        System.out.println("  -index <name>     Elasticsearch index name. Default is 'registry'");
+        System.out.println();
+    }
+
+}

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/UpgradeDDCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/UpgradeDDCmd.java
@@ -1,0 +1,212 @@
+package gov.nasa.pds.registry.mgr.cmd.dd;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Map;
+
+import org.apache.commons.cli.CommandLine;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+
+import com.google.gson.Gson;
+
+import gov.nasa.pds.registry.common.es.client.EsClientFactory;
+import gov.nasa.pds.registry.common.es.client.EsUtils;
+import gov.nasa.pds.registry.common.util.CloseUtils;
+import gov.nasa.pds.registry.mgr.Constants;
+import gov.nasa.pds.registry.mgr.cmd.CliCommand;
+import gov.nasa.pds.registry.mgr.dao.IndexDao;
+import gov.nasa.pds.registry.mgr.dao.RegistryRequestBuilder;
+import gov.nasa.pds.registry.mgr.srv.IndexService;
+
+
+/**
+ * A CLI command to delete records from the data dictionary index in Elasticsearch.
+ * Data can be deleted by ID, or namespace. All data can be also deleted.
+ *  
+ * @author karpenko
+ */
+public class UpgradeDDCmd implements CliCommand
+{
+    private String esUrl;
+    private String indexName;
+    private String authPath;
+
+    /**
+     * Constructor
+     */
+    public UpgradeDDCmd()
+    {
+    }
+
+    
+    @Override
+    public void run(CommandLine cmdLine) throws Exception
+    {
+        if(cmdLine.hasOption("help"))
+        {
+            printHelp();
+            return;
+        }
+
+        esUrl = cmdLine.getOptionValue("es", "http://localhost:9200");
+        indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
+        authPath = cmdLine.getOptionValue("auth");
+        System.out.println("Elasticsearch URL: " + esUrl);
+        
+        boolean replace= cmdLine.hasOption("r");
+
+        RestClient client = null;
+        
+        try
+        {
+            client = EsClientFactory.createRestClient(esUrl, authPath);
+            
+            if(replace)
+            {
+                // Delete old data dictionary index
+                IndexService srv = new IndexService(client);
+                srv.deleteIndex(indexName + "-dd");
+                
+                // Create new data dictionary index
+            }
+        }
+        finally
+        {
+            CloseUtils.close(client);
+        }
+
+    }
+
+    
+    private void deleteById(String id) throws Exception
+    {
+        RestClient client = null;
+        
+        try
+        {
+            // Create Elasticsearch client
+            client = EsClientFactory.createRestClient(esUrl, authPath);
+
+            // Create request
+            RegistryRequestBuilder bld = new RegistryRequestBuilder();
+            String query = bld.createFilterQuery("_id", id);
+            
+            Request req = new Request("POST", "/" + indexName + "-dd" + "/_delete_by_query?refresh=true");
+            req.setJsonEntity(query);
+            
+            // Execute request
+            Response resp = client.performRequest(req);
+            double numDeleted = extractNumDeleted(resp); 
+            
+            System.out.format("Deleted %.0f document(s)\n", numDeleted);
+        }
+        catch(ResponseException ex)
+        {
+            throw new Exception(EsUtils.extractErrorMessage(ex));
+        }
+        finally
+        {
+            CloseUtils.close(client);
+        }        
+    }
+
+    
+    private void deleteByNamespace(String ns) throws Exception
+    {
+        RestClient client = null;
+        
+        try
+        {
+            // Create Elasticsearch client
+            client = EsClientFactory.createRestClient(esUrl, authPath);
+
+            // (1) Delete by class namespace
+            
+            // Create request
+            RegistryRequestBuilder bld = new RegistryRequestBuilder();
+            String query = bld.createFilterQuery("class_ns", ns);
+            
+            Request req = new Request("POST", "/" + indexName + "-dd" + "/_delete_by_query?refresh=true");
+            req.setJsonEntity(query);
+            
+            // Execute request
+            Response resp = client.performRequest(req);
+            double numDeleted = extractNumDeleted(resp); 
+            
+            // (2) Delete by attribute namespace
+            
+            // Create request
+            query = bld.createFilterQuery("attr_ns", ns);
+            
+            req = new Request("POST", "/" + indexName + "-dd" + "/_delete_by_query?refresh=true");
+            req.setJsonEntity(query);
+            
+            // Execute request
+            resp = client.performRequest(req);
+            numDeleted += extractNumDeleted(resp); 
+            
+            System.out.format("Deleted %.0f document(s)\n", numDeleted);
+        }
+        catch(ResponseException ex)
+        {
+            throw new Exception(EsUtils.extractErrorMessage(ex));
+        }
+        finally
+        {
+            CloseUtils.close(client);
+        }        
+    }
+    
+    
+    /**
+     * Extract number of deleted records from Elasticsearch delete API response.
+     * @param resp
+     * @return number of deleted records
+     */
+    @SuppressWarnings("rawtypes")
+    private double extractNumDeleted(Response resp)
+    {
+        try
+        {
+            InputStream is = resp.getEntity().getContent();
+            Reader rd = new InputStreamReader(is);
+            
+            Gson gson = new Gson();
+            Object obj = gson.fromJson(rd, Object.class);
+            rd.close();
+            
+            obj = ((Map)obj).get("deleted");
+            return (Double)obj;
+        }
+        catch(Exception ex)
+        {
+            return 0;
+        }
+    }
+    
+    
+    /**
+     * Print help screen
+     */
+    public void printHelp()
+    {
+        System.out.println("Usage: registry-manager delete-dd <options>");
+
+        System.out.println();
+        System.out.println("Delete data from data dictionary index");
+        System.out.println();
+        System.out.println("Required parameters, one of:");
+        System.out.println("  -id <id>          Delete data by ID (Full field name)");
+        System.out.println("  -ns <namespace>   Delete data by namespace");
+        System.out.println("Optional parameters:");
+        System.out.println("  -auth <file>      Authentication config file");
+        System.out.println("  -es <url>         Elasticsearch URL. Default is http://localhost:9200");
+        System.out.println("  -index <name>     Elasticsearch index name. Default is 'registry'");
+        System.out.println();
+    }
+
+}

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/UpgradeDDCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/UpgradeDDCmd.java
@@ -1,31 +1,20 @@
 package gov.nasa.pds.registry.mgr.cmd.dd;
 
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.Map;
+import java.io.File;
 
 import org.apache.commons.cli.CommandLine;
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.Response;
-import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 
-import com.google.gson.Gson;
-
 import gov.nasa.pds.registry.common.es.client.EsClientFactory;
-import gov.nasa.pds.registry.common.es.client.EsUtils;
+import gov.nasa.pds.registry.common.es.dao.DataLoader;
 import gov.nasa.pds.registry.common.util.CloseUtils;
 import gov.nasa.pds.registry.mgr.Constants;
 import gov.nasa.pds.registry.mgr.cmd.CliCommand;
-import gov.nasa.pds.registry.mgr.dao.IndexDao;
-import gov.nasa.pds.registry.mgr.dao.RegistryRequestBuilder;
 import gov.nasa.pds.registry.mgr.srv.IndexService;
 
 
 /**
- * A CLI command to delete records from the data dictionary index in Elasticsearch.
- * Data can be deleted by ID, or namespace. All data can be also deleted.
+ * A CLI command to upgrade data dictionary index in Elasticsearch.
  *  
  * @author karpenko
  */
@@ -55,7 +44,6 @@ public class UpgradeDDCmd implements CliCommand
         esUrl = cmdLine.getOptionValue("es", "http://localhost:9200");
         indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
         authPath = cmdLine.getOptionValue("auth");
-        System.out.println("Elasticsearch URL: " + esUrl);
         
         boolean replace= cmdLine.hasOption("r");
 
@@ -67,12 +55,15 @@ public class UpgradeDDCmd implements CliCommand
             
             if(replace)
             {
-                // Delete old data dictionary index
+                // Recreate data dictionary index
                 IndexService srv = new IndexService(client);
-                srv.deleteIndex(indexName + "-dd");
-                
-                // Create new data dictionary index
+                srv.reCreateIndex("elastic/data-dic.json", indexName + "-dd");
             }
+            
+            // Load data
+            DataLoader dl = new DataLoader(esUrl, indexName + "-dd", authPath);
+            File zipFile = IndexService.getDataDicFile();
+            dl.loadZippedFile(zipFile, "dd.json");
         }
         finally
         {
@@ -81,131 +72,22 @@ public class UpgradeDDCmd implements CliCommand
 
     }
 
-    
-    private void deleteById(String id) throws Exception
-    {
-        RestClient client = null;
-        
-        try
-        {
-            // Create Elasticsearch client
-            client = EsClientFactory.createRestClient(esUrl, authPath);
-
-            // Create request
-            RegistryRequestBuilder bld = new RegistryRequestBuilder();
-            String query = bld.createFilterQuery("_id", id);
-            
-            Request req = new Request("POST", "/" + indexName + "-dd" + "/_delete_by_query?refresh=true");
-            req.setJsonEntity(query);
-            
-            // Execute request
-            Response resp = client.performRequest(req);
-            double numDeleted = extractNumDeleted(resp); 
-            
-            System.out.format("Deleted %.0f document(s)\n", numDeleted);
-        }
-        catch(ResponseException ex)
-        {
-            throw new Exception(EsUtils.extractErrorMessage(ex));
-        }
-        finally
-        {
-            CloseUtils.close(client);
-        }        
-    }
-
-    
-    private void deleteByNamespace(String ns) throws Exception
-    {
-        RestClient client = null;
-        
-        try
-        {
-            // Create Elasticsearch client
-            client = EsClientFactory.createRestClient(esUrl, authPath);
-
-            // (1) Delete by class namespace
-            
-            // Create request
-            RegistryRequestBuilder bld = new RegistryRequestBuilder();
-            String query = bld.createFilterQuery("class_ns", ns);
-            
-            Request req = new Request("POST", "/" + indexName + "-dd" + "/_delete_by_query?refresh=true");
-            req.setJsonEntity(query);
-            
-            // Execute request
-            Response resp = client.performRequest(req);
-            double numDeleted = extractNumDeleted(resp); 
-            
-            // (2) Delete by attribute namespace
-            
-            // Create request
-            query = bld.createFilterQuery("attr_ns", ns);
-            
-            req = new Request("POST", "/" + indexName + "-dd" + "/_delete_by_query?refresh=true");
-            req.setJsonEntity(query);
-            
-            // Execute request
-            resp = client.performRequest(req);
-            numDeleted += extractNumDeleted(resp); 
-            
-            System.out.format("Deleted %.0f document(s)\n", numDeleted);
-        }
-        catch(ResponseException ex)
-        {
-            throw new Exception(EsUtils.extractErrorMessage(ex));
-        }
-        finally
-        {
-            CloseUtils.close(client);
-        }        
-    }
-    
-    
-    /**
-     * Extract number of deleted records from Elasticsearch delete API response.
-     * @param resp
-     * @return number of deleted records
-     */
-    @SuppressWarnings("rawtypes")
-    private double extractNumDeleted(Response resp)
-    {
-        try
-        {
-            InputStream is = resp.getEntity().getContent();
-            Reader rd = new InputStreamReader(is);
-            
-            Gson gson = new Gson();
-            Object obj = gson.fromJson(rd, Object.class);
-            rd.close();
-            
-            obj = ((Map)obj).get("deleted");
-            return (Double)obj;
-        }
-        catch(Exception ex)
-        {
-            return 0;
-        }
-    }
-    
     
     /**
      * Print help screen
      */
     public void printHelp()
     {
-        System.out.println("Usage: registry-manager delete-dd <options>");
+        System.out.println("Usage: registry-manager upgrade-dd <options>");
 
         System.out.println();
-        System.out.println("Delete data from data dictionary index");
+        System.out.println("Upgrade data dictionary index");
         System.out.println();
-        System.out.println("Required parameters, one of:");
-        System.out.println("  -id <id>          Delete data by ID (Full field name)");
-        System.out.println("  -ns <namespace>   Delete data by namespace");
         System.out.println("Optional parameters:");
-        System.out.println("  -auth <file>      Authentication config file");
-        System.out.println("  -es <url>         Elasticsearch URL. Default is http://localhost:9200");
-        System.out.println("  -index <name>     Elasticsearch index name. Default is 'registry'");
+        System.out.println("  -r              Recreate data dictionary index (replace old data dictionary)");
+        System.out.println("  -auth <file>    Authentication config file");
+        System.out.println("  -es <url>       Elasticsearch URL. Default is http://localhost:9200");
+        System.out.println("  -index <name>   Elasticsearch index name. Default is 'registry'");
         System.out.println();
     }
 

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/reg/CreateRegistryCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/reg/CreateRegistryCmd.java
@@ -46,9 +46,6 @@ public class CreateRegistryCmd implements CliCommand
         int shards = parseShards(cmdLine.getOptionValue("shards", "1"));
         int replicas = parseReplicas(cmdLine.getOptionValue("replicas", "0"));
         
-        System.out.println("Elasticsearch URL: " + esUrl);
-        System.out.println();
-        
         RestClient client = null;
 
         try
@@ -58,17 +55,15 @@ public class CreateRegistryCmd implements CliCommand
             
             // Registry
             srv.createIndex("elastic/registry.json", indexName, shards, replicas);
-            System.out.println();
-            
+
             // Collection inventory (product references)
             srv.createIndex("elastic/refs.json", indexName + "-refs", shards, replicas);
-            System.out.println();
             
             // Data dictionary
             srv.createIndex("elastic/data-dic.json", indexName + "-dd", 1, replicas);
             // Load data
             DataLoader dl = new DataLoader(esUrl, indexName + "-dd", authPath);
-            File zipFile = srv.getDataDicFile();
+            File zipFile = IndexService.getDataDicFile();
             dl.loadZippedFile(zipFile, "dd.json");
         }
         finally

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/reg/CreateRegistryCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/reg/CreateRegistryCmd.java
@@ -105,8 +105,8 @@ public class CreateRegistryCmd implements CliCommand
     
     /**
      * Parse integer
-     * @param str
-     * @return
+     * @param str a string to convert to int
+     * @return parsed int
      */
     private int parseInt(String str)
     {

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/reg/DeleteRegistryCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/reg/DeleteRegistryCmd.java
@@ -38,7 +38,6 @@ public class DeleteRegistryCmd implements CliCommand
         String esUrl = cmdLine.getOptionValue("es", "http://localhost:9200");
         String indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
         String authPath = cmdLine.getOptionValue("auth");
-        System.out.println("Elasticsearch URL: " + esUrl);
 
         RestClient client = null;
         
@@ -50,8 +49,6 @@ public class DeleteRegistryCmd implements CliCommand
             srv.deleteIndex(indexName);
             srv.deleteIndex(indexName + "-refs");
             srv.deleteIndex(indexName + "-dd");
-
-            System.out.println("Done");            
         }
         finally
         {

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/IndexDao.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/IndexDao.java
@@ -4,6 +4,8 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 
+import gov.nasa.pds.registry.mgr.dao.resp.SettingsResponseParser;
+
 
 /**
  * Data Access Object (DAO) to work with Elasticsearch indices.
@@ -36,4 +38,19 @@ public class IndexDao
         return resp.getStatusLine().getStatusCode() == 200;
     }
 
+    
+    /**
+     * Get index settings (number of shards and replicas).
+     * @param indexName Elasticsearch index name
+     * @return index settings
+     * @throws Exception an exception
+     */
+    public IndexSettings getIndexSettings(String indexName) throws Exception
+    {
+        Request req = new Request("GET", "/" + indexName + "/_settings");
+        Response resp = client.performRequest(req);
+        
+        SettingsResponseParser parser = new SettingsResponseParser();
+        return parser.parse(resp);
+    }
 }

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/IndexSettings.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/IndexSettings.java
@@ -1,0 +1,13 @@
+package gov.nasa.pds.registry.mgr.dao;
+
+public class IndexSettings
+{
+    public int shards;
+    public int replicas;
+    
+    public IndexSettings()
+    {
+        shards = -1;
+        replicas = -1;
+    }
+}

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryDao.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryDao.java
@@ -1,0 +1,125 @@
+package gov.nasa.pds.registry.mgr.dao;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+
+import gov.nasa.pds.registry.common.es.client.SearchResponseParser;
+import gov.nasa.pds.registry.common.es.dao.BulkResponseParser;
+import gov.nasa.pds.registry.common.util.CloseUtils;
+import gov.nasa.pds.registry.mgr.dao.resp.GetAltIdsParser;
+
+/**
+ * Data access object
+ * @author karpenko
+ */
+public class RegistryDao
+{
+    private Logger log;
+    
+    private RestClient client;
+    private String indexName;
+
+    private boolean pretty = false;
+
+    /**
+     * Constructor
+     * @param client Elasticsearch client
+     * @param indexName Elasticsearch index
+     */
+    public RegistryDao(RestClient client, String indexName)
+    {
+        log = LogManager.getLogger(this.getClass());
+        
+        this.client = client;
+        this.indexName = indexName;
+    }
+
+    
+    /**
+     * Generate pretty JSONs for debugging
+     * @param b boolean flag
+     */
+    public void setPretty(boolean b)
+    {
+        this.pretty = b;
+    }
+    
+    
+    /**
+     * Get product's alternative IDs by primary key 
+     * @param ids primary keys (usually LIDVIDs)
+     * @return ID map: key = product primary key (usually LIDVID), value = set of alternate IDs 
+     * @throws Exception an exception
+     */
+    public Map<String, Set<String>> getAlternateIds(Collection<String> ids) throws Exception
+    {
+        if(ids == null || ids.isEmpty()) return null;
+        
+        RegistryRequestBuilder bld = new RegistryRequestBuilder();
+        String jsonReq = bld.createGetAlternateIdsRequest(ids);
+        
+        String reqUrl = "/" + indexName + "/_search";
+        if(pretty) reqUrl += "?pretty";
+        
+        Request req = new Request("GET", reqUrl);
+        req.setJsonEntity(jsonReq);
+        Response resp = client.performRequest(req);
+
+        //DebugUtils.dumpResponseBody(resp);
+        
+        GetAltIdsParser cb = new GetAltIdsParser();
+        SearchResponseParser parser = new SearchResponseParser();
+        parser.parseResponse(resp, cb);
+        
+        return cb.getIdMap();
+    }
+    
+    
+    /**
+     * Update alternate IDs by primary keys
+     * @param newIds ID map: key = product primary key (usually LIDVID), 
+     * value = additional alternate IDs to be added to existing alternate IDs.
+     * @throws Exception an exception
+     */
+    public void updateAlternateIds(Map<String, Set<String>> newIds) throws Exception
+    {
+        if(newIds == null || newIds.isEmpty()) return;
+        
+        RegistryRequestBuilder bld = new RegistryRequestBuilder();
+        String json = bld.createUpdateAltIdsRequest(newIds);
+        log.debug("Request:\n" + json);
+        
+        String reqUrl = "/" + indexName + "/_bulk"; //?refresh=wait_for";
+        Request req = new Request("POST", reqUrl);
+        req.setJsonEntity(json);
+        
+        Response resp = client.performRequest(req);
+        
+        // Check for Elasticsearch errors.
+        InputStream is = null;
+        InputStreamReader rd = null;
+        try
+        {
+            is = resp.getEntity().getContent();
+            rd = new InputStreamReader(is);
+            
+            BulkResponseParser parser = new BulkResponseParser();
+            parser.parse(rd);
+        }
+        finally
+        {
+            CloseUtils.close(rd);
+            CloseUtils.close(is);
+        }
+    }
+
+}

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryManager.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryManager.java
@@ -23,6 +23,7 @@ public class RegistryManager
     private RestClient esClient;
     private SchemaDao schemaDao;
     private DataDictionaryDao dataDictionaryDao;
+    private RegistryDao registryDao;
     
     
     /**
@@ -47,7 +48,8 @@ public class RegistryManager
         log.info("Registry index: " + indexName);
         
         schemaDao = new SchemaDao(esClient, indexName);
-        dataDictionaryDao = new DataDictionaryDao(esClient, indexName);                
+        dataDictionaryDao = new DataDictionaryDao(esClient, indexName);
+        registryDao = new RegistryDao(esClient, indexName);
     }
     
     
@@ -101,6 +103,16 @@ public class RegistryManager
     public DataDictionaryDao getDataDictionaryDao()
     {
         return dataDictionaryDao;
+    }
+
+    
+    /**
+     * Get registry DAO object.
+     * @return Registry DAO
+     */
+    public RegistryDao getRegistryDao()
+    {
+        return registryDao;
     }
 
 }

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryRequestBuilder.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryRequestBuilder.java
@@ -5,7 +5,9 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import com.google.gson.Gson;
@@ -269,27 +271,93 @@ public class RegistryRequestBuilder
 
     
     /**
-     * Build update label status request
-     * @param status new PDS label status
-     * @param field filter field name
-     * @param value filter value
+     * Build a query to select alternate ids by document primary key
+     * @param ids list of primary keys (lidvids right now)
      * @return JSON
-     * @throws IOException an exception
+     * @throws Exception an exception
      */
-    public String createUpdateStatusRequest(String status, String field, String value) throws IOException
+    public String createGetAlternateIdsRequest(Collection<String> ids) throws Exception
     {
+        if(ids == null || ids.isEmpty()) throw new Exception("Missing ids");
+            
         StringWriter out = new StringWriter();
         JsonWriter writer = createJsonWriter(out);
 
+        // Create ids query
         writer.beginObject();
-        // Script
-        writer.name("script").value("ctx._source.archive_status = '" + status + "'");
-        // Query
-        EsQueryUtils.appendFilterQuery(writer, field, value);
+
+        // Exclude source from response
+        writer.name("_source").value("alternate_ids");
+        writer.name("size").value(ids.size());
+
+        writer.name("query");
+        writer.beginObject();
+        writer.name("ids");
+        writer.beginObject();
+        
+        writer.name("values");
+        writer.beginArray();
+        for(String id: ids)
+        {
+            writer.value(id);
+        }
+        writer.endArray();
+        
+        writer.endObject();
+        writer.endObject();
         writer.endObject();
 
         writer.close();
         return out.toString();
     }
 
+    
+    public String createUpdateAltIdsRequest(Map<String, Set<String>> newIds) throws Exception
+    {
+        if(newIds == null || newIds.isEmpty()) throw new IllegalArgumentException("Missing ids");
+        
+        StringBuilder bld = new StringBuilder();
+        
+        // Build NJSON (new-line delimited JSON)
+        for(Map.Entry<String, Set<String>> entry: newIds.entrySet())
+        {
+            // Line 1: Elasticsearch document ID
+            bld.append("{ \"update\" : {\"_id\" : \"" + entry.getKey() + "\" } }\n");
+            
+            // Line 2: Data
+            String dataJson = buildUpdateDocJson("alternate_ids", entry.getValue());
+            bld.append(dataJson);
+            bld.append("\n");
+        }
+        
+        return bld.toString();
+
+    }
+    
+    
+    private String buildUpdateDocJson(String field, Collection<String> values) throws Exception
+    {
+        StringWriter out = new StringWriter();
+        JsonWriter writer = createJsonWriter(out);
+
+        writer.beginObject();
+
+        writer.name("doc");
+        writer.beginObject();
+        
+        writer.name(field);
+        
+        writer.beginArray();        
+        for(String value: values)
+        {
+            writer.value(value);
+        }
+        writer.endArray();
+        
+        writer.endObject();        
+        writer.endObject();
+        
+        writer.close();
+        return out.toString();
+    }
 }

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/resp/GetAltIdsParser.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/resp/GetAltIdsParser.java
@@ -1,0 +1,58 @@
+package gov.nasa.pds.registry.mgr.dao.resp;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import gov.nasa.pds.registry.common.es.client.SearchResponseParser;
+
+
+public class GetAltIdsParser implements SearchResponseParser.Callback
+{
+    private Map<String, Set<String>> map;
+    
+    
+    public GetAltIdsParser()
+    {
+        map = new TreeMap<>();
+    }
+
+    
+    public Map<String, Set<String>> getIdMap()
+    {
+        return map;
+    }
+    
+    
+    @Override
+    public void onRecord(String id, Object rec) throws Exception
+    {
+        if(rec instanceof Map<?, ?>)
+        {
+            Object obj = ((Map<?, ?>)rec).get("alternate_ids");
+            if(obj == null) return;
+            
+            // Multiple values
+            if(obj instanceof List<?>)
+            {
+                Set<String> altIds = new TreeSet<>();
+                for(Object item: (List<?>)obj)
+                {
+                    altIds.add(item.toString());
+                }
+                
+                map.put(id, altIds);
+            }
+            // Single value
+            else if(obj instanceof String)
+            {
+                Set<String> altIds = new TreeSet<>();
+                altIds.add((String)obj);
+                map.put(id, altIds);
+            }
+        }
+    }
+
+}

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/resp/SettingsResponseParser.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/resp/SettingsResponseParser.java
@@ -1,0 +1,102 @@
+package gov.nasa.pds.registry.mgr.dao.resp;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import org.elasticsearch.client.Response;
+
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+
+import gov.nasa.pds.registry.mgr.dao.IndexSettings;
+
+/**
+ * Parse Elasticsearch "/index_name/_settings" response.
+ * @author karpenko
+ */
+public class SettingsResponseParser
+{
+    /**
+     * Constructor
+     */
+    public SettingsResponseParser()
+    {
+    }
+
+    
+    /**
+     * Parse Elasticsearch response
+     * @param resp Elasticsearch response
+     * @return index settings
+     * @throws Exception an exception
+     */
+    public IndexSettings parse(Response resp) throws Exception
+    {
+        if(resp == null) return null;
+        
+        InputStream is = resp.getEntity().getContent();
+        if(is == null) return null;
+        
+        JsonReader rd = new JsonReader(new InputStreamReader(is));
+        
+        rd.beginObject();   // root
+        rd.nextName();      // index name
+        
+        rd.beginObject();
+        rd.nextName();      // "settings"
+        
+        rd.beginObject();
+
+        IndexSettings settings = new IndexSettings();
+        
+        while(rd.hasNext() && rd.peek() != JsonToken.END_OBJECT)
+        {
+            String name = rd.nextName();
+            if("index".equals(name))
+            {
+                parseIndex(rd, settings);
+            }
+            else
+            {
+                rd.skipValue();
+            }
+        }
+        
+        rd.endObject();
+        rd.endObject();
+        rd.endObject();
+        
+        rd.close();
+        
+        return settings;
+    }
+    
+    
+    private void parseIndex(JsonReader rd, IndexSettings settings) throws Exception
+    {
+        if(rd == null) throw new IllegalArgumentException("JsonReader is null");
+        if(settings == null) throw new IllegalArgumentException("Settings is null");
+        
+        rd.beginObject();
+        
+        while(rd.hasNext() && rd.peek() != JsonToken.END_OBJECT)
+        {
+            String name = rd.nextName();
+            if("number_of_shards".equals(name))
+            {
+                settings.shards = rd.nextInt();
+            }
+            else if("number_of_replicas".equals(name))
+            {
+                settings.replicas = rd.nextInt();
+            }
+            else
+            {
+                rd.skipValue();
+            }
+        }
+        
+        rd.endObject();
+    }
+    
+}

--- a/src/main/java/gov/nasa/pds/registry/mgr/srv/IndexService.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/srv/IndexService.java
@@ -1,0 +1,142 @@
+package gov.nasa.pds.registry.mgr.srv;
+
+import java.io.File;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+
+import gov.nasa.pds.registry.common.es.client.EsUtils;
+import gov.nasa.pds.registry.mgr.dao.IndexDao;
+import gov.nasa.pds.registry.mgr.dao.RegistryRequestBuilder;
+
+/**
+ * A service to work with Elasticsearch indices
+ * @author karpenko
+ */
+public class IndexService
+{
+    private static final String ERR_CFG = 
+            "Could not find default configuration directory. REGISTRY_MANAGER_HOME environment variable is not set."; 
+
+    private RestClient client;
+    private IndexDao indexDao;
+    
+    
+    /**
+     * Constructor
+     * @param client Elasticsearch client
+     */
+    public IndexService(RestClient client)
+    {
+        this.client = client;
+        indexDao = new IndexDao(client);
+    }
+
+    
+    /**
+     * Create Elasticsearch index
+     * @param relativeSchemaPath Relative path to Elasticsearch index schema file.
+     * The path is relative to $REGISTRY_MANGER_HOME, e.g., "elastic/registry.json"
+     * @param indexName Elasticsearch index name
+     * @param shards number of shards
+     * @param replicas number of replicas
+     * @throws Exception
+     */
+    public void createIndex(String relativeSchemaPath, String indexName, int shards, int replicas) throws Exception
+    {
+        File schemaFile = getSchemaFile(relativeSchemaPath);
+        
+        try
+        {
+            System.out.println("Creating index...");
+            System.out.println("   Index: " + indexName);
+            System.out.println("  Schema: " + schemaFile.getAbsolutePath());
+            System.out.println("  Shards: " + shards);
+            System.out.println("Replicas: " + replicas);
+            
+            // Create request
+            Request req = new Request("PUT", "/" + indexName);
+            RegistryRequestBuilder bld = new RegistryRequestBuilder();
+            String jsonReq = bld.createCreateIndexRequest(schemaFile, shards, replicas);
+            req.setJsonEntity(jsonReq);
+
+            // Execute request
+            Response resp = client.performRequest(req);
+            EsUtils.printWarnings(resp);
+            System.out.println("Done");
+        }
+        catch(ResponseException ex)
+        {
+            throw new Exception(EsUtils.extractErrorMessage(ex));
+        }
+    }
+
+    
+    /**
+     * Get Elasticsearch schema file by relative path.
+     * @param relPath
+     * @return
+     * @throws Exception
+     */
+    public File getSchemaFile(String relPath) throws Exception
+    {
+        String home = System.getenv("REGISTRY_MANAGER_HOME");
+        if(home == null) throw new Exception(ERR_CFG);
+
+        File file = new File(home, relPath);
+        if(!file.exists()) throw new Exception("Schema file " + file.getAbsolutePath() + " does not exist");
+        
+        return file;
+    }
+
+    
+    /**
+     * Get default data dictionary data file.
+     * @return
+     * @throws Exception
+     */
+    public File getDataDicFile() throws Exception
+    {
+        String home = System.getenv("REGISTRY_MANAGER_HOME");
+        if(home == null) 
+        {
+            throw new Exception(ERR_CFG);
+        }
+        
+        File file = new File(home, "elastic/data-dic-data.jar");
+        return file;
+    }
+
+    
+    /**
+     * Delete Elasticsearch index by name
+     * @param indexName Elasticsearch index name
+     * @throws Exception
+     */
+    public void deleteIndex(String indexName) throws Exception
+    {
+        try
+        {
+            System.out.println("Deleting index " + indexName);
+            
+            if(!indexDao.indexExists(indexName)) 
+            {
+                return;
+            }
+
+            // Create request
+            Request req = new Request("DELETE", "/" + indexName);
+
+            // Execute request
+            Response resp = client.performRequest(req);
+            EsUtils.printWarnings(resp);
+        }
+        catch(ResponseException ex)
+        {
+            throw new Exception(EsUtils.extractErrorMessage(ex));
+        }
+    }
+
+}

--- a/src/main/resources/elastic/registry.json
+++ b/src/main/resources/elastic/registry.json
@@ -29,6 +29,7 @@
       "lid": { "type": "keyword" },
       "vid": { "type": "float" },
       "lidvid": { "type": "keyword" },
+      "alternate_ids": { "type": "keyword" },
 
       "title": {"type": "text", "analyzer": "english"},
       "description": {"type": "text", "analyzer": "english"},

--- a/src/main/resources/elastic/registry.json
+++ b/src/main/resources/elastic/registry.json
@@ -47,8 +47,8 @@
       "ops:Label_File_Info/ops:file_name": { "type": "keyword" },
       "ops:Label_File_Info/ops:file_size": { "type": "long" },
       "ops:Label_File_Info/ops:md5_checksum": { "type": "keyword" },
-      "ops:Label_File_Info/ops:blob": { "type": "binary", "index": false },
-      "ops:Label_File_Info/ops:json_blob": { "type": "binary", "index": false },
+      "ops:Label_File_Info/ops:blob": { "type": "binary" },
+      "ops:Label_File_Info/ops:json_blob": { "type": "binary" },
 
       "ops:Data_File_Info/ops:creation_date_time": { "type": "date" },
       "ops:Data_File_Info/ops:file_ref": { "type": "keyword" },

--- a/src/test/java/tt/TestEsQueryBuilder.java
+++ b/src/test/java/tt/TestEsQueryBuilder.java
@@ -11,9 +11,6 @@ public class TestEsQueryBuilder
         
         testDelete();
         System.out.println();
-        
-        testUpdateStatus();
-        System.out.println();
     }
 
 
@@ -33,10 +30,4 @@ public class TestEsQueryBuilder
     }
 
     
-    private static void testUpdateStatus() throws Exception
-    {
-        RegistryRequestBuilder bld = new RegistryRequestBuilder(true);
-        String json = bld.createUpdateStatusRequest("STAGED", "lidvid", "test::1.0");
-        System.out.println(json);
-    }
 }

--- a/src/test/java/tt/TestIndexDao.java
+++ b/src/test/java/tt/TestIndexDao.java
@@ -1,0 +1,30 @@
+package tt;
+
+import org.elasticsearch.client.RestClient;
+
+import gov.nasa.pds.registry.common.es.client.EsClientFactory;
+import gov.nasa.pds.registry.mgr.dao.IndexDao;
+import gov.nasa.pds.registry.mgr.dao.IndexSettings;
+
+
+public class TestIndexDao
+{
+
+    public static void main(String[] args) throws Exception
+    {
+        RestClient client = EsClientFactory.createRestClient("localhost", null);
+        
+        try
+        {
+            IndexDao dao = new IndexDao(client);
+            
+            IndexSettings data = dao.getIndexSettings("registry-dd");            
+            System.out.println(data.shards + ", " + data.replicas);
+        }
+        finally
+        {
+            client.close();
+        }
+    }
+
+}

--- a/src/test/java/tt/TestRegistryDao.java
+++ b/src/test/java/tt/TestRegistryDao.java
@@ -1,0 +1,33 @@
+package tt;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+
+import org.elasticsearch.client.RestClient;
+
+import gov.nasa.pds.registry.common.es.client.EsClientFactory;
+import gov.nasa.pds.registry.mgr.dao.RegistryDao;
+
+
+public class TestRegistryDao
+{
+
+    public static void main(String[] args) throws Exception
+    {
+        RestClient client = EsClientFactory.createRestClient("localhost", null);
+        
+        try
+        {
+            RegistryDao dao = new RegistryDao(client, "registry");
+            Map<String, Set<String>> idMap = dao.getAlternateIds(Arrays.asList("urn:nasa:pds:context:instrument:vg1.crs::1.0"));
+            Set<String> altIds = idMap.get("urn:nasa:pds:context:instrument:vg1.crs::1.0");
+            System.out.println(altIds);
+        }
+        finally
+        {
+            client.close();
+        }
+    }
+
+}


### PR DESCRIPTION
## 🗒️ Summary
Added upgrade-dd command to Registry manager to upgrade data dictionary

**NOTE:** This branch includes changes from branch `versions` (https://github.com/NASA-PDS/registry-mgr/pull/46)

## ⚙️ Test Data and/or Report
* Run `registry-manager upgrade-dd -r`
* Check that `registry-dd` index was dropped and recreated and that data dictionary was loaded. You should see output similar to this:
```
[INFO] Deleting index registry-dd                                                                                                                      
[INFO] Creating index: registry-dd
[INFO] Schema: C:\tmp\registry-manager-4.5.0-SNAPSHOT\elastic\data-dic.json
[INFO] Shards: 1
[INFO] Replicas: 0
[INFO] Loading ES data file: C:\tmp\registry-manager-4.5.0-SNAPSHOT\elastic\data-dic-data.jar:dd.json
[INFO] Loaded 500 document(s)
[INFO] Loaded 1000 document(s)
[INFO] Loaded 1500 document(s)
[INFO] Loaded 2000 document(s)
[INFO] Loaded 2500 document(s)
[INFO] Loaded 3000 document(s)
[INFO] Loaded 3122 document(s)
```

## ♻️ Related Issues
https://github.com/NASA-PDS/registry/issues/43
