### PR TITLE
issue 50: add all known ref_lid_*

### DIFF
--- a/src/main/resources/elastic/registry.json
+++ b/src/main/resources/elastic/registry.json
@@ -1,61 +1,66 @@
 {
-  "settings": {
-    "index.mapping.total_fields.limit": "3000",
-    "number_of_shards": 1,
-    "number_of_replicas": 0,
-    "analysis": {
-      "normalizer": {
-        "keyword_lowercase": {
-          "type": "custom",
-          "filter": ["lowercase"]
+    "settings":
+    {
+        "index.mapping.total_fields.limit": "3000",
+        "number_of_shards": 1,
+        "number_of_replicas": 0,
+        "analysis":
+        {
+            "normalizer":
+            {"keyword_lowercase":{"type":"custom", "filter":["lowercase"]}}
         }
-      }
-    }
-  },
+    },
 
-  "mappings": {
-    "dynamic": false,
-    "dynamic_templates": [
-      {
-        "strings": {
-          "match_mapping_type": "string",
-          "mapping": {
-            "type": "keyword"
-          }
+    "mappings":
+    {
+        "dynamic": false,
+        "dynamic_templates":
+        [
+            {
+                "strings":{"match_mapping_type":"string",
+                           "mapping":{"type":"keyword"}}
+            }
+        ],
+        "properties":
+        {
+            "lid": { "type": "keyword" },
+            "vid": { "type": "float" },
+            "lidvid": { "type": "keyword" },
+            "alternate_ids": { "type": "keyword" },
+
+            "title": {"type": "text", "analyzer": "english"},
+            "description": {"type": "text", "analyzer": "english"},
+
+            "product_class": { "type": "keyword" },
+            "_package_id": { "type": "keyword" },
+
+            "ops:Tracking_Meta/ops:archive_status": { "type": "keyword" }, 
+
+            "ops:Harvest_Info/ops:node_name": { "type": "keyword" },
+            "ops:Harvest_Info/ops:harvest_date_time": { "type": "date" },
+
+            "ops:Label_File_Info/ops:creation_date_time": { "type": "date" },
+            "ops:Label_File_Info/ops:file_ref": { "type": "keyword" },
+            "ops:Label_File_Info/ops:file_name": { "type": "keyword" },
+            "ops:Label_File_Info/ops:file_size": { "type": "long" },
+            "ops:Label_File_Info/ops:md5_checksum": { "type": "keyword" },
+            "ops:Label_File_Info/ops:blob": { "type": "binary" },
+            "ops:Label_File_Info/ops:json_blob": { "type": "binary" },
+
+            "ops:Data_File_Info/ops:creation_date_time": { "type": "date" },
+            "ops:Data_File_Info/ops:file_ref": { "type": "keyword" },
+            "ops:Data_File_Info/ops:file_name": { "type": "keyword" },
+            "ops:Data_File_Info/ops:file_size": { "type": "long" },
+            "ops:Data_File_Info/ops:md5_checksum": { "type": "keyword" },
+            "ops:Data_File_Info/ops:mime_type": { "type": "keyword" },
+
+            "ref_lid_collection":{"type":"keyword"},
+            "ref_lid_collection_secondary":{"type":"keyword"},
+            "ref_lid_document":{"type":"keyword"},
+            "ref_lid_instrument":{"type":"keyword"},
+            "ref_lid_instrument_host":{"type":"keyword"},
+            "ref_lid_investigation":{"type":"keyword"},
+            "ref_lid_target":{"type":"keyword"}
         }
-      }
-    ],
-    "properties": {
-      "lid": { "type": "keyword" },
-      "vid": { "type": "float" },
-      "lidvid": { "type": "keyword" },
-      "alternate_ids": { "type": "keyword" },
-
-      "title": {"type": "text", "analyzer": "english"},
-      "description": {"type": "text", "analyzer": "english"},
-
-      "product_class": { "type": "keyword" },
-      "_package_id": { "type": "keyword" },
-
-      "ops:Tracking_Meta/ops:archive_status": { "type": "keyword" }, 
-
-      "ops:Harvest_Info/ops:node_name": { "type": "keyword" },
-      "ops:Harvest_Info/ops:harvest_date_time": { "type": "date" },
-
-      "ops:Label_File_Info/ops:creation_date_time": { "type": "date" },
-      "ops:Label_File_Info/ops:file_ref": { "type": "keyword" },
-      "ops:Label_File_Info/ops:file_name": { "type": "keyword" },
-      "ops:Label_File_Info/ops:file_size": { "type": "long" },
-      "ops:Label_File_Info/ops:md5_checksum": { "type": "keyword" },
-      "ops:Label_File_Info/ops:blob": { "type": "binary" },
-      "ops:Label_File_Info/ops:json_blob": { "type": "binary" },
-
-      "ops:Data_File_Info/ops:creation_date_time": { "type": "date" },
-      "ops:Data_File_Info/ops:file_ref": { "type": "keyword" },
-      "ops:Data_File_Info/ops:file_name": { "type": "keyword" },
-      "ops:Data_File_Info/ops:file_size": { "type": "long" },
-      "ops:Data_File_Info/ops:md5_checksum": { "type": "keyword" },
-      "ops:Data_File_Info/ops:mime_type": { "type": "keyword" }
     }
-  }
 }


### PR DESCRIPTION
## 🗒️ Summary
Added missing keys to registry.json

## ⚙️ Test Data and/or Report
open search requests now work:

````
$ curl --insecure --location --request GET 'https://localhost:9200/registry/_search' --header 'Accept: application/json' --header 'Content-Type: application/json' --user admin:admin -d @Projects/PDS/q1.json | jq
{
  "took": 2,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 1,
      "relation": "eq"
    },
    "max_score": 0.39556286,
    "hits": [
      {
        "_index": "registry",
        "_id": "urn:nasa:pds:insight_rad::2.1",
        "_score": 0.39556286,
        "_source": {
          "lid": "urn:nasa:pds:insight_rad",
          "ref_lid_collection": [
            "urn:nasa:pds:insight_rad:data_calibrated",
            "urn:nasa:pds:insight_rad:data_derived",
            "urn:nasa:pds:insight_rad:data_raw"
          ]
        }
      }
    ]
  }
}
```

## ♻️ Related Issues

NASA-PDS/registry#81
NASA-PDS/registry-api#150
