### PR TITLE
remove command line use of index name

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/mgr/Constants.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/Constants.java
@@ -7,9 +7,6 @@ package gov.nasa.pds.registry.mgr;
  */
 public interface Constants
 {
-    // Indices
-    public static final String DEFAULT_REGISTRY_INDEX = "registry";
-
     // Fields
     public static final String NS_SEPARATOR = ":";
     public static final String ATTR_SEPARATOR = "/";

--- a/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
@@ -326,9 +326,6 @@ public class RegistryManagerCli
         options.addOption(bld.build());
         
         // Registry
-        bld = Option.builder("index").hasArg().argName("name");
-        options.addOption(bld.build());
-
         bld = Option.builder("schema").hasArg().argName("path");
         options.addOption(bld.build());
 

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/DeleteDataCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/DeleteDataCmd.java
@@ -7,7 +7,6 @@ import gov.nasa.pds.registry.common.EstablishConnectionFactory;
 import gov.nasa.pds.registry.common.Request;
 import gov.nasa.pds.registry.common.ResponseException;
 import gov.nasa.pds.registry.common.RestClient;
-import gov.nasa.pds.registry.mgr.Constants;
 import gov.nasa.pds.registry.mgr.cmd.CliCommand;
 
 
@@ -40,24 +39,22 @@ public class DeleteDataCmd implements CliCommand
         }
 
         String esUrl = cmdLine.getOptionValue("es", "app:/connections/direct/localhost.xml");
-        String indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
         String authPath = cmdLine.getOptionValue("auth");
 
 
         System.out.println("Elasticsearch URL: " + esUrl);
-        System.out.println("            Index: " + indexName);
         System.out.println(filterMessage);
         System.out.println();
                 
         ConnectionFactory conFact = EstablishConnectionFactory.from(esUrl, authPath);
         try (RestClient client = conFact.createRestClient()) {
-          Request.DeleteByQuery regQuery = client.createDeleteByQuery().setIndex(indexName),
-                                refQuery = client.createDeleteByQuery().setIndex(indexName + "-refs");
+          Request.DeleteByQuery regQuery = client.createDeleteByQuery().setIndex(conFact.getIndexName()),
+                                refQuery = client.createDeleteByQuery().setIndex(conFact.getIndexName() + "-refs");
           buildEsQuery(cmdLine, regQuery, refQuery);
             // Delete from registry index
-            deleteByQuery(indexName, client.performRequest(regQuery));
+            deleteByQuery(conFact.getIndexName(), client.performRequest(regQuery));
             // Delete from product references index
-            deleteByQuery(indexName + "-refs", client.performRequest(refQuery));
+            deleteByQuery(conFact.getIndexName() + "-refs", client.performRequest(refQuery));
         }
         catch(ResponseException ex)
         {

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/ExportDataCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/ExportDataCmd.java
@@ -4,7 +4,6 @@ import java.io.File;
 
 import org.apache.commons.cli.CommandLine;
 
-import gov.nasa.pds.registry.mgr.Constants;
 import gov.nasa.pds.registry.mgr.cmd.CliCommand;
 import gov.nasa.pds.registry.mgr.dao.RegistryDataExporter;
 
@@ -48,7 +47,6 @@ public class ExportDataCmd implements CliCommand
         }
         
         String esUrl = cmdLine.getOptionValue("es", "app:/connections/direct/localhost.xml");
-        String indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
         String authPath = cmdLine.getOptionValue("auth");
 
         extractFilterParams(cmdLine);
@@ -58,11 +56,10 @@ public class ExportDataCmd implements CliCommand
         }
 
         System.out.println("Elasticsearch URL: " + esUrl);
-        System.out.println("            Index: " + indexName);
         System.out.println(getFilterMessage());
         System.out.println();
         
-        RegistryDataExporter exp = new RegistryDataExporter(esUrl, indexName, authPath);
+        RegistryDataExporter exp = new RegistryDataExporter(esUrl, authPath);
         exp.setFilterField(filterFieldName, filterFieldValue);
         exp.export(new File(filePath));
     }

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/ExportFileCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/ExportFileCmd.java
@@ -42,7 +42,6 @@ public class ExportFileCmd implements CliCommand
         }
         
         String esUrl = cmdLine.getOptionValue("es", "app:/connections/direct/localhost.xml");
-        String indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
         String authPath = cmdLine.getOptionValue("auth");
         
         // Lidvid
@@ -60,7 +59,6 @@ public class ExportFileCmd implements CliCommand
         }
 
         System.out.println("Elasticsearch URL: " + esUrl);
-        System.out.println("            Index: " + indexName);
         System.out.println("           LIDVID: " + lidvid);
         System.out.println("      Output file: " + filePath);
         System.out.println();
@@ -68,7 +66,7 @@ public class ExportFileCmd implements CliCommand
         ConnectionFactory conFact = EstablishConnectionFactory.from(esUrl, authPath);        
         try (RestClient client = conFact.createRestClient())
         {
-          Request.Search req = client.createSearchRequest().setIndex(indexName).buildGetField(Constants.BLOB_FIELD, lidvid);
+          Request.Search req = client.createSearchRequest().buildGetField(Constants.BLOB_FIELD, lidvid);
           String blob = client.performRequest(req).field(Constants.BLOB_FIELD);
           if(blob == null)
           {

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/SetArchiveStatusCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/SetArchiveStatusCmd.java
@@ -4,13 +4,13 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.apache.commons.cli.CommandLine;
+import gov.nasa.pds.registry.common.ConnectionFactory;
 import gov.nasa.pds.registry.common.EstablishConnectionFactory;
 import gov.nasa.pds.registry.common.ResponseException;
 import gov.nasa.pds.registry.common.RestClient;
 import gov.nasa.pds.registry.common.es.dao.ProductDao;
 import gov.nasa.pds.registry.common.es.service.ProductService;
 import gov.nasa.pds.registry.common.util.CloseUtils;
-import gov.nasa.pds.registry.mgr.Constants;
 import gov.nasa.pds.registry.mgr.cmd.CliCommand;
 
 
@@ -44,7 +44,6 @@ public class SetArchiveStatusCmd implements CliCommand {
         }
 
         String esUrl = cmdLine.getOptionValue("es", "app:/connections/direct/localhost.xml");
-        String indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
         String authPath = cmdLine.getOptionValue("auth");
         
         String status = getStatus(cmdLine);
@@ -57,8 +56,9 @@ public class SetArchiveStatusCmd implements CliCommand {
         try
         {
             // Call Elasticsearch
-            client = EstablishConnectionFactory.from(esUrl, authPath).createRestClient();
-            ProductDao dao = new ProductDao(client, indexName);
+            ConnectionFactory conFact = EstablishConnectionFactory.from(esUrl, authPath);
+            client = conFact.createRestClient();
+            ProductDao dao = new ProductDao(client, conFact.getIndexName());
             ProductService srv = new ProductService(dao);
             
             srv.updateArchveStatus(lidvid, status);

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/UpdateAltIdsCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/UpdateAltIdsCmd.java
@@ -16,7 +16,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import gov.nasa.pds.registry.common.ResponseException;
 import gov.nasa.pds.registry.common.util.CloseUtils;
-import gov.nasa.pds.registry.mgr.Constants;
 import gov.nasa.pds.registry.mgr.cmd.CliCommand;
 import gov.nasa.pds.registry.mgr.dao.RegistryDao;
 import gov.nasa.pds.registry.mgr.dao.RegistryManager;
@@ -49,7 +48,6 @@ public class UpdateAltIdsCmd implements CliCommand
             return;
         }
         String url = cmdLine.getOptionValue("es", "app:/connections/direct/localhost.xml");
-        String indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
         String authFile = cmdLine.getOptionValue("auth");
         String filePath = cmdLine.getOptionValue("file");
         if(filePath == null) throw new Exception("Missing required parameter '-file'");
@@ -58,7 +56,7 @@ public class UpdateAltIdsCmd implements CliCommand
         
         try
         {
-            RegistryManager.init(url, authFile, indexName);
+            RegistryManager.init(url, authFile);
             updateIds(file);
         }
         catch(ResponseException ex)

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/DeleteDDCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/DeleteDDCmd.java
@@ -7,7 +7,6 @@ import gov.nasa.pds.registry.common.EstablishConnectionFactory;
 import gov.nasa.pds.registry.common.Request;
 import gov.nasa.pds.registry.common.ResponseException;
 import gov.nasa.pds.registry.common.RestClient;
-import gov.nasa.pds.registry.mgr.Constants;
 import gov.nasa.pds.registry.mgr.cmd.CliCommand;
 
 
@@ -21,7 +20,6 @@ public class DeleteDDCmd implements CliCommand
 {
   private ConnectionFactory conFact;
     private String esUrl;
-    private String indexName;
     private String authPath;
 
     /**
@@ -42,9 +40,8 @@ public class DeleteDDCmd implements CliCommand
         }
 
         esUrl = cmdLine.getOptionValue("es", "app:/connections/direct/localhost.xml");
-        indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
         authPath = cmdLine.getOptionValue("auth");
-        this.conFact = EstablishConnectionFactory.from(esUrl, authPath).setIndexName(indexName);
+        this.conFact = EstablishConnectionFactory.from(esUrl, authPath);
         String id = cmdLine.getOptionValue("id");
         if(id != null)
         {

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/ExportDDCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/ExportDDCmd.java
@@ -4,7 +4,6 @@ import java.io.File;
 
 import org.apache.commons.cli.CommandLine;
 
-import gov.nasa.pds.registry.mgr.Constants;
 import gov.nasa.pds.registry.mgr.cmd.CliCommand;
 import gov.nasa.pds.registry.mgr.dao.dd.DDDataExporter;
 
@@ -41,14 +40,12 @@ public class ExportDDCmd implements CliCommand
         }
         
         String esUrl = cmdLine.getOptionValue("es", "app:/connections/direct/localhost.xml");
-        String indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
         String authPath = cmdLine.getOptionValue("auth");
 
         System.out.println("Elasticsearch URL: " + esUrl);
-        System.out.println("            Index: " + indexName);
         System.out.println();
         
-        DDDataExporter exp = new DDDataExporter(esUrl, indexName, authPath);
+        DDDataExporter exp = new DDDataExporter(esUrl, authPath);
         exp.export(new File(filePath));
     }
 

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/ListDDCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/ListDDCmd.java
@@ -7,7 +7,6 @@ import org.apache.commons.cli.CommandLine;
 
 import gov.nasa.pds.registry.common.es.dao.dd.DataDictionaryDao;
 import gov.nasa.pds.registry.common.es.dao.dd.LddInfo;
-import gov.nasa.pds.registry.mgr.Constants;
 import gov.nasa.pds.registry.mgr.cmd.CliCommand;
 import gov.nasa.pds.registry.mgr.dao.RegistryManager;
 
@@ -36,14 +35,13 @@ public class ListDDCmd implements CliCommand
         }
 
         String url = cmdLine.getOptionValue("es", "app:/connections/direct/localhost.xml");
-        String indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
         String authFile = cmdLine.getOptionValue("auth");
         
         String namespace = cmdLine.getOptionValue("ns");
         
         try
         {
-            RegistryManager.init(url, authFile, indexName);
+            RegistryManager.init(url, authFile);
             
             DataDictionaryDao dao = RegistryManager.getInstance().getDataDictionaryDao();
             List<LddInfo> list = dao.listLdds(namespace);

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/LoadDDCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/LoadDDCmd.java
@@ -9,7 +9,6 @@ import gov.nasa.pds.registry.common.dd.LddUtils;
 import gov.nasa.pds.registry.common.es.dao.DataLoader;
 import gov.nasa.pds.registry.common.es.dao.dd.DataDictionaryDao;
 import gov.nasa.pds.registry.common.es.service.JsonLddLoader;
-import gov.nasa.pds.registry.mgr.Constants;
 import gov.nasa.pds.registry.mgr.cmd.CliCommand;
 import gov.nasa.pds.registry.mgr.dao.RegistryManager;
 import gov.nasa.pds.registry.mgr.dd.CsvLddLoader;
@@ -70,10 +69,9 @@ public class LoadDDCmd implements CliCommand
         }
 
         this.url = cmdLine.getOptionValue("es", "app:/connections/direct/localhost.xml");
-        this.indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
         this.authFile = cmdLine.getOptionValue("auth");
         
-        RegistryManager.init(url, authFile, indexName);
+        RegistryManager.init(url, authFile);
 
         try
         {

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/UpgradeDDCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/UpgradeDDCmd.java
@@ -8,7 +8,6 @@ import gov.nasa.pds.registry.common.EstablishConnectionFactory;
 import gov.nasa.pds.registry.common.RestClient;
 import gov.nasa.pds.registry.common.es.dao.DataLoader;
 import gov.nasa.pds.registry.common.util.CloseUtils;
-import gov.nasa.pds.registry.mgr.Constants;
 import gov.nasa.pds.registry.mgr.cmd.CliCommand;
 import gov.nasa.pds.registry.mgr.srv.IndexService;
 
@@ -21,7 +20,6 @@ import gov.nasa.pds.registry.mgr.srv.IndexService;
 public class UpgradeDDCmd implements CliCommand
 {
     private String esUrl;
-    private String indexName;
     private String authPath;
 
     /**
@@ -42,7 +40,6 @@ public class UpgradeDDCmd implements CliCommand
         }
 
         esUrl = cmdLine.getOptionValue("es", "app:/connections/direct/localhost.xml");
-        indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
         authPath = cmdLine.getOptionValue("auth");
         
         boolean replace= cmdLine.hasOption("r");
@@ -58,11 +55,11 @@ public class UpgradeDDCmd implements CliCommand
             {
                 // Recreate data dictionary index
                 IndexService srv = new IndexService(client);
-                srv.reCreateIndex("elastic/data-dic.json", indexName + "-dd");
+                srv.reCreateIndex("elastic/data-dic.json", conFact.getIndexName() + "-dd");
             }
             
             // Load data
-            DataLoader dl = new DataLoader(conFact.setIndexName(indexName + "-dd"));
+            DataLoader dl = new DataLoader(conFact.setIndexName(conFact.getIndexName() + "-dd"));
             File zipFile = IndexService.getDataDicFile();
             dl.loadZippedFile(zipFile, "dd.json");
         }

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/reg/CreateRegistryCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/reg/CreateRegistryCmd.java
@@ -8,7 +8,6 @@ import gov.nasa.pds.registry.common.EstablishConnectionFactory;
 import gov.nasa.pds.registry.common.RestClient;
 import gov.nasa.pds.registry.common.es.dao.DataLoader;
 import gov.nasa.pds.registry.common.util.CloseUtils;
-import gov.nasa.pds.registry.mgr.Constants;
 import gov.nasa.pds.registry.mgr.cmd.CliCommand;
 import gov.nasa.pds.registry.mgr.srv.IndexService;
 
@@ -40,9 +39,7 @@ public class CreateRegistryCmd implements CliCommand
         }
 
         String esUrl = cmdLine.getOptionValue("es", "app://connections/direct/localhost.xml");
-        String indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
         String authPath = cmdLine.getOptionValue("auth");
-        
         int shards = parseShards(cmdLine.getOptionValue("shards", "1"));
         int replicas = parseReplicas(cmdLine.getOptionValue("replicas", "0"));
         
@@ -53,6 +50,7 @@ public class CreateRegistryCmd implements CliCommand
           ConnectionFactory conFact = EstablishConnectionFactory.from(esUrl, authPath);
             client = conFact.createRestClient();
             IndexService srv = new IndexService(client);
+            String indexName = conFact.getIndexName();
             
             // Registry
             srv.createIndex("elastic/registry.json", indexName, shards, replicas);

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/reg/DeleteRegistryCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/reg/DeleteRegistryCmd.java
@@ -1,10 +1,10 @@
 package gov.nasa.pds.registry.mgr.cmd.reg;
 
 import org.apache.commons.cli.CommandLine;
+import gov.nasa.pds.registry.common.ConnectionFactory;
 import gov.nasa.pds.registry.common.EstablishConnectionFactory;
 import gov.nasa.pds.registry.common.RestClient;
 import gov.nasa.pds.registry.common.util.CloseUtils;
-import gov.nasa.pds.registry.mgr.Constants;
 import gov.nasa.pds.registry.mgr.cmd.CliCommand;
 import gov.nasa.pds.registry.mgr.srv.IndexService;
 
@@ -35,15 +35,16 @@ public class DeleteRegistryCmd implements CliCommand
         }
         
         String esUrl = cmdLine.getOptionValue("es", "app:/connections/direct/localhost.xml");
-        String indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
         String authPath = cmdLine.getOptionValue("auth");
 
         RestClient client = null;
         
         try
         {
-            client = EstablishConnectionFactory.from(esUrl, authPath).createRestClient();
+          ConnectionFactory conFact = EstablishConnectionFactory.from(esUrl, authPath);
+            client = conFact.createRestClient();
             IndexService srv = new IndexService(client);
+            String indexName = conFact.getIndexName();
 
             srv.deleteIndex(indexName);
             srv.deleteIndex(indexName + "-refs");

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryDataExporter.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryDataExporter.java
@@ -19,9 +19,9 @@ public class RegistryDataExporter extends DataExporter
      * @param indexName Elasticsearch index name
      * @param authConfigFile authentication configuration file
      */
-    public RegistryDataExporter(String esUrl, String indexName, String authConfigFile)
+    public RegistryDataExporter(String esUrl, String authConfigFile)
     {
-        super(esUrl, indexName, authConfigFile);
+        super(esUrl, "", authConfigFile);
     }
     
 

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryManager.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/RegistryManager.java
@@ -2,6 +2,7 @@ package gov.nasa.pds.registry.mgr.dao;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import gov.nasa.pds.registry.common.ConnectionFactory;
 import gov.nasa.pds.registry.common.EstablishConnectionFactory;
 import gov.nasa.pds.registry.common.RestClient;
 import gov.nasa.pds.registry.common.es.dao.dd.DataDictionaryDao;
@@ -29,25 +30,19 @@ public class RegistryManager
      * @param cfg Registry (Elasticsearch) configuration parameters.
      * @throws Exception Generic exception
      */
-    private RegistryManager(String connURL, String authFile, String index) throws Exception
+    private RegistryManager(String connURL, String authFile) throws Exception
     {
         if(connURL == null || connURL.isEmpty()) throw new IllegalArgumentException("Missing Registry URL");
         
-        client = EstablishConnectionFactory.from(connURL, authFile).createRestClient();
+        ConnectionFactory conFact = EstablishConnectionFactory.from(connURL, authFile);
+        client = conFact.createRestClient();
         
-        String indexName = index;
-        if(indexName == null || indexName.isEmpty()) 
-        {
-            indexName = "registry";
-        }
-
         Logger log = LogManager.getLogger(this.getClass());
         log.info("Registry URL: " + connURL);
-        log.info("Registry index: " + indexName);
         
-        schemaDao = new SchemaDao(client, indexName);
-        dataDictionaryDao = new DataDictionaryDao(client, indexName);
-        registryDao = new RegistryDao(client, indexName);
+        schemaDao = new SchemaDao(client, conFact.getIndexName());
+        dataDictionaryDao = new DataDictionaryDao(client, conFact.getIndexName());
+        registryDao = new RegistryDao(client, conFact.getIndexName());
     }
     
     
@@ -56,9 +51,9 @@ public class RegistryManager
      * @param cfg Registry (Elasticsearch) configuration parameters.
      * @throws Exception Generic exception
      */
-    public static void init(String connURL, String authFile, String index) throws Exception
+    public static void init(String connURL, String authFile) throws Exception
     {
-        instance = new RegistryManager(connURL, authFile, index);
+        instance = new RegistryManager(connURL, authFile);
     }
     
     

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/dd/DDDataExporter.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/dd/DDDataExporter.java
@@ -16,9 +16,9 @@ public class DDDataExporter extends DataExporter
      * @param indexName Elasticsearch index name
      * @param authConfigFile authentication configuration file
      */
-    public DDDataExporter(String esUrl, String indexName, String authConfigFile)
+    public DDDataExporter(String esUrl, String authConfigFile)
     {
-        super(esUrl, indexName + "-dd", authConfigFile);
+        super(esUrl, "-dd", authConfigFile);
     }
     @Override
     protected Search createRequest(Search req, int batchSize, String searchAfter) {

--- a/src/test/java/tools/LoadLdds.java
+++ b/src/test/java/tools/LoadLdds.java
@@ -16,13 +16,12 @@ public class LoadLdds
     public static void main(String[] args) throws Exception
     {
         String url = "app:/connections/direct/localhost.xml";
-        String indexName = "registry";
         
         BufferedReader rd = null;
         
         try
         {
-            RegistryManager.init(url, null, indexName);
+            RegistryManager.init(url, null);
             
             DataDictionaryDao ddDao = RegistryManager.getInstance().getDataDictionaryDao();
             JsonLddLoader loader = new JsonLddLoader(ddDao, EstablishConnectionFactory.from("app:/connections/direct/localhost.xml").setIndexName("registry"));

--- a/src/test/java/tt/TestLddLoader.java
+++ b/src/test/java/tt/TestLddLoader.java
@@ -13,11 +13,10 @@ public class TestLddLoader
     public static void main(String[] args) throws Exception
     {
         String url = "app:/connections/direct/localhost.xml";
-        String indexName = "registry";
         
         try
         {
-            RegistryManager.init(url, null, indexName);
+            RegistryManager.init(url, null);
             
             DataDictionaryDao ddDao = RegistryManager.getInstance().getDataDictionaryDao();
             JsonLddLoader loader = new JsonLddLoader(ddDao, EstablishConnectionFactory.from("app:/connections/direct/localhost.xml").setIndexName("t1"));


### PR DESCRIPTION
## 🗒️ Summary
Remove all uses of CLI index name.

## ⚙️ Test Data and/or Report
Nothing of note other than manual tests confirm basic functions like create and delete index are successful.

## ♻️ Related Issues
step 1 of NASA-PDS/registry-common#48
