### PR TITLE
changes for new pattern in log4j

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/mgr/util/log/Log4jConfigurator.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/util/log/Log4jConfigurator.java
@@ -56,7 +56,7 @@ public class Log4jConfigurator
     {
         AppenderComponentBuilder appender = cfg.newAppender(name, "CONSOLE");
         appender.addAttribute("target", ConsoleAppender.Target.SYSTEM_OUT);
-        appender.add(cfg.newLayout("PatternLayout").addAttribute("pattern", "[%level] %msg%n%throwable"));
+        appender.add(cfg.newLayout("PatternLayout").addAttribute("pattern", "%d{yyyy-MM-dd HH:mm:ss} [%-5p] (%F:%M:%L) %m%n%throwable"));
         cfg.add(appender);
     }
     
@@ -74,7 +74,7 @@ public class Log4jConfigurator
         AppenderComponentBuilder appender = cfg.newAppender(name, "FILE");
         appender.addAttribute("fileName", filePath);
         appender.addAttribute("append", false);
-        appender.add(cfg.newLayout("PatternLayout").addAttribute("pattern", "%d [%level] %msg%n%throwable"));
+        appender.add(cfg.newLayout("PatternLayout").addAttribute("pattern", "%d{yyyy-MM-dd HH:mm:ss} [%-5p] (%F:%M:%L) %m%n%throwable"));
         cfg.add(appender);
     }
     


### PR DESCRIPTION
## 🗒️ Summary
Update to latest log4j pattern

## ⚙️ Test Data and/or Report
Now looks like:
```
2024-11-14 10:28:55 [INFO ] (IndexService.java:createIndex:56) Shards: 1
2024-11-14 10:28:55 [INFO ] (IndexService.java:createIndex:57) Replicas: 0
2024-11-14 10:28:56 [INFO ] (IndexService.java:createIndex:54) Creating index: dev-registry-refs
2024-11-14 10:28:56 [INFO ] (IndexService.java:createIndex:55) Schema: /home/niessner/Projects/PDS/registry-mgr/target/classes/elastic/refs.json
2024-11-14 10:28:56 [INFO ] (IndexService.java:createIndex:56) Shards: 1
```
## ♻️ Related Issues
Partial NASA-PDS/harvest#203

