### PR TITLE
Improve `list-dd` CLI command argument handling

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/ListDDCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/ListDDCmd.java
@@ -34,11 +34,16 @@ public class ListDDCmd implements CliCommand
             return;
         }
 
-        String url = cmdLine.getOptionValue("es", "app:/connections/direct/localhost.xml");
         String authFile = cmdLine.getOptionValue("auth");
-        
         String namespace = cmdLine.getOptionValue("ns");
-        
+        String url = cmdLine.getOptionValue("es", "app:/connections/direct/localhost.xml");
+
+        if (authFile == null || authFile.isBlank()) {
+          throw new IllegalArgumentException("missing argument: -auth must be given");
+        }
+        if (namespace == null || namespace.isBlank()) {
+          throw new IllegalArgumentException("missing argument: -ns must be given");         
+        }
         try
         {
             RegistryManager.init(url, authFile);


### PR DESCRIPTION
## 🗒️ Summary
Checked that arguments without a default are not null or blank before proceeding. Implemented the hits to LddInfo.

## ⚙️ Test Data and/or Report
Run command without -ns and see:
```
[ERROR] missing argument: -ns must be given
```

## ♻️ Related Issues
Closes #121