### PR TITLE
Updated parent POM to take advantage of new Central Repo Portal

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -85,6 +85,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -132,7 +136,7 @@
         "filename": "pom.xml",
         "hashed_secret": "fac2dea9e49a83a2d6ee38c580d1e5358b45efa5",
         "is_verified": false,
-        "line_number": 197
+        "line_number": 223
       }
     ],
     "src/main/resources/auth/auth.cfg": [
@@ -145,5 +149,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-20T16:15:59Z"
+  "generated_at": "2025-06-19T19:54:52Z"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@ POSSIBILITY OF SUCH DAMAGE.
 
     <!-- Inherit release profile, reporting, SNAPSHOT repo, etc. from parent repo -->
     <parent>
-        <groupId>gov.nasa</groupId>
-        <artifactId>pds</artifactId>
-        <version>1.18.0</version>
+        <groupId>gov.nasa.pds</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.19.0</version>
     </parent>
     
     <groupId>gov.nasa.pds</groupId>


### PR DESCRIPTION
## 🗒️ Summary

The older [OSSRH is being decommissioned in favor of the new Maven Central Repository Portal](https://github.com/NASA-PDS/software-issues-repo/issues/128). The parent POM now takes advantage of it and has been published.

For this repository to do the same, it must inherit from the new parent POM. Merge this to achieve that.

## ⚙️ Test Data and/or Report

Not applicable; however any checks that fail below are likely orthogonal to this change.

## ♻️ Related Issues

- https://github.com/NASA-PDS/software-issues-repo/issues/128
- https://github.com/NASA-PDS/software-issues-repo/issues/131
